### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/floating-ip.js
+++ b/floating-ip.js
@@ -1,6 +1,7 @@
 // AWS: http://docs.aws.amazon.com/cli/latest/reference/ec2/allocate-address.html
 // Google: https://cloud.google.com/compute/docs/configure-instance-ip-addresses#reserve_new_static
-var nginx = require("github.com/quilt/nginx");
+const {createDeployment, Machine, MachineRule} = require("@quilt/quilt");
+var nginx = require("@quilt/nginx");
 
 var floatingIp = "xxx.xxx.xxx.xxx (CHANGE ME)"
 var deployment = createDeployment({});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@quilt/infrastructure",
+  "version": "0.0.1",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt",
+    "@quilt/nginx": "quilt/nginx"
+  }
+}


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.