### PR TITLE
floating-ip: Update call to Nginx constructor

### DIFF
--- a/floating-ip.js
+++ b/floating-ip.js
@@ -6,7 +6,7 @@ var nginx = require("@quilt/nginx");
 var floatingIp = "xxx.xxx.xxx.xxx (CHANGE ME)"
 var deployment = createDeployment({});
 
-var app = nginx.New(80);
+var app = nginx.createService(80);
 
 app.place(new MachineRule(false, {floatingIp: floatingIp}));
 deployment.deploy(app);


### PR DESCRIPTION
The nginx spec changed to export a function createService
instead of New to instantiate a new nginx service.